### PR TITLE
Add tests for zlibBuffer and zlibBufferSync

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -252,6 +252,9 @@ function zlibBufferSync (engine, buffer) {
   return engine._processChunk(buffer, flushFlag)
 }
 
+exports.zlibBuffer = zlibBuffer;
+exports.zlibBufferSync = zlibBufferSync;
+
 // generic zlib
 // minimal 2-byte header
 function Deflate (opts) {


### PR DESCRIPTION
Hi, i noted that the synchronous API via `zlibBufferSync` is broken in upstream master (https://github.com/devongovett/browserify-zlib/issues/20). Why not adding tests for that here too?

For easier testing, this also exports `zlibBuffer` and `zlibBufferSync`.
I think this is not an option, or?
