### PR TITLE
fix(package): Use src/index.js as the library entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "zlib",
     "browserify"
   ],
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
This PR will change the module's entry point from lib/index.js to src/index.js. The current version doesn't include lib/ in npm and as such the module, when installed from npm, is not working. This PR will fix that.